### PR TITLE
Add minimal React/Vite frontend and runnable docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,34 @@ A complete FastAPI URL shortener with short-link creation, redirects, analytics,
 
 ## Run locally
 
+### Backend only
+
 ```bash
 pip install -r requirements.txt
 uvicorn url_shortener.main:app --reload
 ```
+
+### Frontend dashboard
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend expects the FastAPI backend at `http://localhost:8000` by default. Override this with `VITE_API_BASE_URL` if needed.
+
+### Docker Compose
+
+```bash
+cd infra
+docker compose up
+```
+
+This starts:
+
+- FastAPI backend on `http://localhost:8000`
+- Vite frontend on `http://localhost:3000`
 
 ## API endpoints
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>URL Shortener</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "url-shortener-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 3000",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  API_BASE_URL,
+  createShortUrl,
+  deleteShortUrl,
+  getAnalytics,
+  listShortUrls,
+} from './api';
+
+const initialForm = {
+  url: '',
+  customAlias: '',
+  expiresInDays: '',
+};
+
+function formatDate(value) {
+  if (!value) {
+    return '—';
+  }
+
+  return new Date(value).toLocaleString();
+}
+
+function StatList({ title, items }) {
+  const entries = Object.entries(items || {});
+
+  return (
+    <div className="stat-card">
+      <h4>{title}</h4>
+      {entries.length === 0 ? (
+        <p className="muted">No data yet.</p>
+      ) : (
+        <ul>
+          {entries.map(([key, count]) => (
+            <li key={key}>
+              <span>{key}</span>
+              <strong>{count}</strong>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function App() {
+  const [items, setItems] = useState([]);
+  const [form, setForm] = useState(initialForm);
+  const [selectedCode, setSelectedCode] = useState('');
+  const [analytics, setAnalytics] = useState(null);
+  const [loadingList, setLoadingList] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [loadingAnalytics, setLoadingAnalytics] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const activeItems = useMemo(() => items.filter((item) => item.is_active), [items]);
+
+  async function refreshList(nextSelectedCode) {
+    setLoadingList(true);
+    try {
+      const data = await listShortUrls();
+      setItems(data);
+
+      if (nextSelectedCode) {
+        setSelectedCode(nextSelectedCode);
+      } else if (data.length > 0 && !data.some((item) => item.short_code === selectedCode)) {
+        setSelectedCode(data[0].short_code);
+      } else if (data.length === 0) {
+        setSelectedCode('');
+        setAnalytics(null);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoadingList(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshList();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedCode) {
+      setAnalytics(null);
+      return;
+    }
+
+    async function loadAnalytics() {
+      setLoadingAnalytics(true);
+      setError('');
+      try {
+        const data = await getAnalytics(selectedCode);
+        setAnalytics(data);
+      } catch (err) {
+        setAnalytics(null);
+        setError(err.message);
+      } finally {
+        setLoadingAnalytics(false);
+      }
+    }
+
+    loadAnalytics();
+  }, [selectedCode]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const created = await createShortUrl(form);
+      setForm(initialForm);
+      setSuccess(`Created short URL ${created.short_url}`);
+      await refreshList(created.short_code);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(shortCode) {
+    setError('');
+    setSuccess('');
+
+    try {
+      await deleteShortUrl(shortCode);
+      setSuccess(`Deleted short code ${shortCode}`);
+      const nextCode = selectedCode === shortCode ? '' : selectedCode;
+      await refreshList(nextCode);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="page-shell">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">Frontend dashboard</p>
+          <h1>URL Shortener</h1>
+          <p className="muted">Create, browse, delete, and inspect analytics for the FastAPI backend.</p>
+        </div>
+        <div className="backend-chip">Backend: {API_BASE_URL}</div>
+      </header>
+
+      {error ? <div className="banner error">{error}</div> : null}
+      {success ? <div className="banner success">{success}</div> : null}
+
+      <main className="layout">
+        <section className="card">
+          <h2>Create short URL</h2>
+          <form className="form-grid" onSubmit={handleSubmit}>
+            <label>
+              Original URL
+              <input
+                required
+                type="url"
+                placeholder="https://example.com/article"
+                value={form.url}
+                onChange={(event) => setForm((current) => ({ ...current, url: event.target.value }))}
+              />
+            </label>
+            <label>
+              Custom alias
+              <input
+                type="text"
+                placeholder="optional-alias"
+                value={form.customAlias}
+                onChange={(event) => setForm((current) => ({ ...current, customAlias: event.target.value }))}
+              />
+            </label>
+            <label>
+              Expires in days
+              <input
+                type="number"
+                min="1"
+                max="3650"
+                placeholder="optional"
+                value={form.expiresInDays}
+                onChange={(event) => setForm((current) => ({ ...current, expiresInDays: event.target.value }))}
+              />
+            </label>
+            <button type="submit" disabled={submitting}>
+              {submitting ? 'Creating…' : 'Create short URL'}
+            </button>
+          </form>
+        </section>
+
+        <section className="card">
+          <div className="section-header">
+            <h2>Short URLs</h2>
+            <button type="button" className="secondary" onClick={() => refreshList()} disabled={loadingList}>
+              {loadingList ? 'Refreshing…' : 'Refresh'}
+            </button>
+          </div>
+
+          {loadingList ? (
+            <p className="muted">Loading URLs…</p>
+          ) : items.length === 0 ? (
+            <p className="muted">No short URLs created yet.</p>
+          ) : (
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Original URL</th>
+                    <th>Clicks</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <tr key={item.short_code} className={selectedCode === item.short_code ? 'selected-row' : ''}>
+                      <td>
+                        <button
+                          type="button"
+                          className="link-button"
+                          onClick={() => setSelectedCode(item.short_code)}
+                        >
+                          {item.short_code}
+                        </button>
+                      </td>
+                      <td>
+                        <a href={item.original_url} target="_blank" rel="noreferrer">
+                          {item.original_url}
+                        </a>
+                      </td>
+                      <td>{item.click_count}</td>
+                      <td>{item.is_active ? 'Active' : 'Inactive'}</td>
+                      <td>
+                        <div className="action-row">
+                          <button type="button" className="secondary" onClick={() => setSelectedCode(item.short_code)}>
+                            Analytics
+                          </button>
+                          <button
+                            type="button"
+                            className="danger"
+                            onClick={() => handleDelete(item.short_code)}
+                            disabled={!item.is_active}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <p className="muted compact">Active links: {activeItems.length} / {items.length}</p>
+        </section>
+
+        <section className="card analytics-card">
+          <div className="section-header">
+            <h2>Analytics</h2>
+            <select value={selectedCode} onChange={(event) => setSelectedCode(event.target.value)} disabled={items.length === 0}>
+              {items.length === 0 ? <option value="">No short URLs</option> : null}
+              {items.map((item) => (
+                <option key={item.short_code} value={item.short_code}>
+                  {item.short_code}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {!selectedCode ? (
+            <p className="muted">Select a short code to view analytics.</p>
+          ) : loadingAnalytics ? (
+            <p className="muted">Loading analytics…</p>
+          ) : analytics ? (
+            <>
+              <div className="analytics-overview">
+                <div>
+                  <span className="label">Short URL</span>
+                  <a href={analytics.short_url} target="_blank" rel="noreferrer">{analytics.short_url}</a>
+                </div>
+                <div>
+                  <span className="label">Original URL</span>
+                  <span>{analytics.original_url}</span>
+                </div>
+                <div>
+                  <span className="label">Total clicks</span>
+                  <strong>{analytics.total_clicks}</strong>
+                </div>
+                <div>
+                  <span className="label">Last click</span>
+                  <span>{formatDate(analytics.last_clicked_at)}</span>
+                </div>
+              </div>
+
+              <div className="stats-grid">
+                <StatList title="Top referrers" items={analytics.top_referrers} />
+                <StatList title="Browsers" items={analytics.browser_breakdown} />
+                <StatList title="Devices" items={analytics.device_breakdown} />
+              </div>
+
+              <div>
+                <h3>Recent clicks</h3>
+                {analytics.recent_clicks.length === 0 ? (
+                  <p className="muted">No click events recorded yet.</p>
+                ) : (
+                  <div className="table-wrap">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Timestamp</th>
+                          <th>IP</th>
+                          <th>Referer</th>
+                          <th>Browser</th>
+                          <th>Device</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {analytics.recent_clicks.map((click, index) => (
+                          <tr key={`${click.timestamp}-${index}`}>
+                            <td>{formatDate(click.timestamp)}</td>
+                            <td>{click.ip_address || '—'}</td>
+                            <td>{click.referer || 'direct'}</td>
+                            <td>{click.browser || 'unknown'}</td>
+                            <td>{click.device_type || 'unknown'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="muted">Analytics unavailable for this short code.</p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,57 @@
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+const API_PREFIX = `${API_BASE_URL}/api/v1`;
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_PREFIX}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  const payload = contentType.includes('application/json') ? await response.json() : await response.text();
+
+  if (!response.ok) {
+    const detail = typeof payload === 'object' && payload !== null && 'detail' in payload
+      ? payload.detail
+      : 'Request failed';
+    throw new Error(detail);
+  }
+
+  return payload;
+}
+
+export function createShortUrl({ url, customAlias, expiresInDays }) {
+  const body = {
+    url,
+    custom_alias: customAlias || null,
+    expires_in_days: expiresInDays ? Number(expiresInDays) : null,
+  };
+
+  return request('/shorten', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function listShortUrls() {
+  return request('/shorten');
+}
+
+export function deleteShortUrl(shortCode) {
+  return request(`/shorten/${shortCode}`, {
+    method: 'DELETE',
+  });
+}
+
+export function getAnalytics(shortCode) {
+  return request(`/analytics/${shortCode}`);
+}
+
+export { API_BASE_URL };

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,251 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f5f7fb;
+  color: #14213d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f7f9fc 0%, #edf2fb 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: 0;
+  border-radius: 0.75rem;
+  padding: 0.8rem 1rem;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button.secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+button.danger {
+  background: #dc2626;
+}
+
+.page-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.eyebrow {
+  margin: 0;
+  color: #2563eb;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.backend-chip,
+.banner,
+.card,
+.stat-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #dbe4f0;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+}
+
+.backend-chip {
+  padding: 0.9rem 1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+}
+
+.banner {
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+}
+
+.banner.error {
+  color: #991b1b;
+  border-color: #fecaca;
+  background: #fff1f2;
+}
+
+.banner.success {
+  color: #166534;
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.layout {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.card {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+}
+
+.section-header {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 0.8rem 0.95rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.85rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: top;
+}
+
+.selected-row {
+  background: #eff6ff;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.link-button {
+  background: transparent;
+  color: #2563eb;
+  padding: 0;
+}
+
+.analytics-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.analytics-overview {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.analytics-overview > div,
+.stat-card {
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.label {
+  display: block;
+  color: #475569;
+  font-size: 0.85rem;
+  margin-bottom: 0.25rem;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stat-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.stat-card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.stat-card li:last-child {
+  border-bottom: none;
+}
+
+.muted {
+  color: #475569;
+}
+
+.compact {
+  margin-bottom: 0;
+}
+
+a {
+  color: #1d4ed8;
+}
+
+@media (max-width: 720px) {
+  .page-shell {
+    padding: 1rem;
+  }
+
+  .hero,
+  .section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  backend:
+    image: python:3.11-slim
+    working_dir: /app
+    command: >-
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn url_shortener.main:app --host 0.0.0.0 --port 8000"
+    volumes:
+      - ../:/app
+    ports:
+      - "8000:8000"
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app/frontend
+    command: >-
+      sh -c "npm install && npm run dev"
+    environment:
+      VITE_API_BASE_URL: http://localhost:8000
+    volumes:
+      - ../:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend


### PR DESCRIPTION
### Motivation
- Provide a minimal web UI so the project includes create/list/delete/analytics views for short URLs rather than an empty frontend stub.
- Make the frontend a real, runnable developer experience by populating `package.json` with scripts and dependencies and implementing an API client targeting the FastAPI backend.
- Supply a simple local orchestration (`docker-compose`) that matches the repo layout so reviewers can run the backend and frontend together, and remove the unused NGINX placeholder.

### Description
- Added a small React/Vite frontend under `frontend/` including `index.html`, `vite.config.js`, `src/main.jsx`, `src/App.jsx`, and `src/styles.css` that implements create/list/delete and analytics views. 
- Implemented `frontend/src/api.js` as the frontend API client calling the FastAPI endpoints (`/api/v1/shorten`, `/api/v1/analytics`) with configurable `VITE_API_BASE_URL` and centralized error handling.
- Populated `frontend/package.json` with `dev`, `build`, and `preview` scripts and React/Vite dependencies for local development.
- Added `infra/docker-compose.yml` that defines runnable `backend` and `frontend` services mounted from the repository and exposed on ports `8000` and `3000` respectively.
- Removed the unused `infra/nginx.conf` stub and updated `README.md` with backend, frontend, and Docker Compose run instructions.

### Testing
- Ran `pytest`, which completed successfully (4 tests passed).
- Ran `python -m compileall url_shortener`, which completed successfully and produced bytecode caches.
- Attempted `npm install` in `frontend/`, but dependency installation failed in this environment due to a `403 Forbidden` response from the package registry, so a frontend build could not be completed here.
- Attempted to validate `docker compose -f infra/docker-compose.yml config`, but Docker is not available in this environment so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1922fb9148320a1505f5114a0e801)