### PR TITLE
Refactor FastAPI services to use persistent repositories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ passlib[bcrypt]==1.7.4
 nanoid==2.0.0
 httpx==0.28.1
 pytest==8.3.5
+
+aiosqlite==0.20.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,21 @@
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+TEST_DB_PATH = ROOT / "url_shortener.db"
+os.environ.setdefault("DATABASE_URL", f"sqlite+aiosqlite:///{TEST_DB_PATH}")
+
+
+@pytest.fixture(autouse=True)
+def reset_sqlite_db() -> None:
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink()
+    yield
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink()

--- a/url_shortener/api/shorten.py
+++ b/url_shortener/api/shorten.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, Request, status
 
-from url_shortener.core.rate_limit import InMemoryRateLimiter
+from url_shortener.core.rate_limit import RateLimiter
 from url_shortener.models.schemas import URLCreateRequest, URLResponse, URLSummary
 from url_shortener.services.url_service import URLService
 
@@ -13,7 +13,7 @@ def get_url_service(request: Request) -> URLService:
     return request.app.state.url_service
 
 
-def get_rate_limiter(request: Request) -> InMemoryRateLimiter:
+def get_rate_limiter(request: Request) -> RateLimiter:
     return request.app.state.rate_limiter
 
 
@@ -22,7 +22,7 @@ async def create_short_url(
     payload: URLCreateRequest,
     request: Request,
     url_service: URLService = Depends(get_url_service),
-    rate_limiter: InMemoryRateLimiter = Depends(get_rate_limiter),
+    rate_limiter: RateLimiter = Depends(get_rate_limiter),
 ) -> URLResponse:
     await rate_limiter.enforce(request)
     record = await url_service.create_short_url(payload)

--- a/url_shortener/core/config.py
+++ b/url_shortener/core/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 from typing import List
 
 from pydantic import Field
@@ -26,12 +27,21 @@ class Settings(BaseSettings):
     anonymous_rate_limit: int = 30
     default_rate_limit: int = 100
     rate_limit_window: int = 3600
+    database_url: str = Field(
+        default_factory=lambda: f"sqlite+aiosqlite:///{Path.cwd() / 'url_shortener.db'}"
+    )
+    valkey_url: str | None = None
     allowed_origins: List[str] = Field(
         default_factory=lambda: ["http://localhost:3000", "http://localhost:8080"]
     )
 
     def normalized_base_domain(self) -> str:
         return self.base_domain.rstrip("/")
+
+    def get_database_url_async(self) -> str:
+        if self.database_url.startswith("postgresql://"):
+            return self.database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        return self.database_url
 
 
 @lru_cache(maxsize=1)

--- a/url_shortener/core/rate_limit.py
+++ b/url_shortener/core/rate_limit.py
@@ -1,34 +1,41 @@
 from __future__ import annotations
 
-from collections import defaultdict, deque
-from datetime import datetime, timedelta, timezone
-from typing import Deque, Dict
+from typing import Protocol
 
 from fastapi import HTTPException, Request, status
 
 from url_shortener.core.config import Settings
+from url_shortener.db.valkey import ValkeyManager
 
 
-class InMemoryRateLimiter:
-    """Simple fixed-window rate limiter used for anonymous clients."""
+class RateLimiter(Protocol):
+    async def enforce(self, request: Request) -> None:
+        ...
 
-    def __init__(self, settings: Settings):
+
+class NoOpRateLimiter:
+    async def enforce(self, request: Request) -> None:
+        return None
+
+
+class ValkeyRateLimiter:
+    """Shared fixed-window rate limiter backed by Valkey."""
+
+    def __init__(self, settings: Settings, valkey_manager: ValkeyManager):
         self.settings = settings
-        self._requests: Dict[str, Deque[datetime]] = defaultdict(deque)
+        self.valkey_manager = valkey_manager
 
     async def enforce(self, request: Request) -> None:
-        identifier = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "anonymous")
-        now = datetime.now(timezone.utc)
-        window_start = now - timedelta(seconds=self.settings.rate_limit_window)
-        timestamps = self._requests[identifier]
-
-        while timestamps and timestamps[0] < window_start:
-            timestamps.popleft()
-
-        if len(timestamps) >= self.settings.anonymous_rate_limit:
+        identifier = request.headers.get("x-forwarded-for") or (
+            request.client.host if request.client else "anonymous"
+        )
+        is_allowed, _ = await self.valkey_manager.rate_limit_check(
+            identifier=identifier,
+            limit=self.settings.anonymous_rate_limit,
+            window=self.settings.rate_limit_window,
+        )
+        if not is_allowed:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Rate limit exceeded",
             )
-
-        timestamps.append(now)

--- a/url_shortener/db/models.py
+++ b/url_shortener/db/models.py
@@ -8,8 +8,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
 from datetime import datetime
 

--- a/url_shortener/db/postgres.py
+++ b/url_shortener/db/postgres.py
@@ -1,69 +1,104 @@
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.pool import NullPool
-from sqlalchemy import text
-import logging
-from typing import AsyncGenerator
+from __future__ import annotations
+
+import asyncio
 from contextlib import asynccontextmanager
+import logging
+from typing import Any, AsyncGenerator, Callable, TypeVar
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, sessionmaker
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 class DatabaseManager:
     def __init__(self, database_url: str):
         self.database_url = database_url
         self.engine = None
+        self.sync_engine = None
         self.session_factory = None
+        self.sync_session_factory = None
+
+    @property
+    def is_sqlite(self) -> bool:
+        return self.database_url.startswith("sqlite")
 
     async def initialize(self) -> None:
-        """Initialize database engine and session factory"""
-        self.engine = create_async_engine(
-            self.database_url,
-            echo=False,  # Set to True for SQL logging
-            pool_size=20,
-            max_overflow=30,
-            pool_pre_ping=True,
-            pool_recycle=3600,  # Recycle connections after 1 hour
-            poolclass=None,  # Default QueuePool
-        )
-
-        self.session_factory = async_sessionmaker(
-            bind=self.engine,
-            class_=AsyncSession,
-            expire_on_commit=False,
-        )
+        """Initialize database engine and session factory."""
+        if self.is_sqlite:
+            sync_database_url = self.database_url.replace("+aiosqlite", "")
+            self.sync_engine = create_engine(
+                sync_database_url,
+                echo=False,
+                pool_pre_ping=True,
+                connect_args={"check_same_thread": False},
+            )
+            self.sync_session_factory = sessionmaker(
+                bind=self.sync_engine,
+                class_=Session,
+                expire_on_commit=False,
+            )
+        else:
+            self.engine = create_async_engine(
+                self.database_url,
+                echo=False,
+                pool_pre_ping=True,
+                pool_size=20,
+                max_overflow=30,
+                pool_recycle=3600,
+            )
+            self.session_factory = async_sessionmaker(
+                bind=self.engine,
+                class_=AsyncSession,
+                expire_on_commit=False,
+            )
 
         await self._test_connection()
         logger.info("Database initialized successfully")
 
     async def _test_connection(self) -> None:
-        """Test database connection"""
+        """Test database connection."""
         try:
-            async with self.engine.begin() as conn:
-                await conn.execute(text("SELECT 1"))
+            if self.is_sqlite:
+                await self.run_sync(lambda session: session.execute(text("SELECT 1")))
+            else:
+                async with self.engine.begin() as conn:
+                    await conn.execute(text("SELECT 1"))
             logger.info("Database connection test successful")
         except Exception as e:
             logger.error(f"Database connection test failed: {e}")
             raise
 
     async def create_tables(self) -> None:
-        """Create all tables"""
+        """Create all tables."""
         from .models import Base
 
-        async with self.engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+        if self.is_sqlite:
+            await asyncio.to_thread(Base.metadata.create_all, self.sync_engine)
+        else:
+            async with self.engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
         logger.info("Database tables created successfully")
 
     async def close(self) -> None:
-        """Close database connections"""
+        """Close database connections."""
         if self.engine:
             await self.engine.dispose()
-            logger.info("Database connections closed")
+            self.engine = None
+            self.session_factory = None
+        if self.sync_engine:
+            await asyncio.to_thread(self.sync_engine.dispose)
+            self.sync_engine = None
+            self.sync_session_factory = None
+        logger.info("Database connections closed")
 
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:
-        """Get database session with automatic cleanup"""
+        """Get async database session with automatic cleanup."""
         if not self.session_factory:
-            raise RuntimeError("Database not initialized. Call initialize() first.")
+            raise RuntimeError("Async database not initialized. Call initialize() first.")
 
         async with self.session_factory() as session:
             try:
@@ -76,14 +111,35 @@ class DatabaseManager:
             finally:
                 await session.close()
 
-    async def execute_raw_sql(self, query: str, params: dict = None) -> any:
-        """Execute raw SQL query"""
+    async def run_sync(self, operation: Callable[[Session], T]) -> T:
+        """Run synchronous session work in a thread for sqlite-backed tests/dev."""
+        if not self.sync_session_factory:
+            raise RuntimeError("Sync database not initialized. Call initialize() first.")
+
+        def runner() -> T:
+            session = self.sync_session_factory()
+            try:
+                result = operation(session)
+                session.commit()
+                return result
+            except Exception:
+                session.rollback()
+                raise
+            finally:
+                session.close()
+
+        return await asyncio.to_thread(runner)
+
+    async def execute_raw_sql(self, query: str, params: dict | None = None) -> Any:
+        """Execute raw SQL query."""
+        if self.is_sqlite:
+            return await self.run_sync(lambda session: session.execute(text(query), params or {}))
+
         async with self.get_session() as session:
-            result = await session.execute(text(query), params or {})
-            return result
+            return await session.execute(text(query), params or {})
 
     async def health_check(self) -> bool:
-        """Check database health"""
+        """Check database health."""
         try:
             await self._test_connection()
             return True
@@ -97,11 +153,11 @@ db_manager = DatabaseManager("")
 
 
 async def get_database() -> DatabaseManager:
-    """Get database manager instance"""
+    """Get database manager instance."""
     return db_manager
 
 
 async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Dependency for FastAPI to get database session"""
+    """Dependency for FastAPI to get database session."""
     async with db_manager.get_session() as session:
         yield session

--- a/url_shortener/main.py
+++ b/url_shortener/main.py
@@ -7,7 +7,11 @@ from url_shortener.api.analytics import router as analytics_router
 from url_shortener.api.redirect import router as redirect_router
 from url_shortener.api.shorten import router as shorten_router
 from url_shortener.core.config import get_settings
-from url_shortener.core.rate_limit import InMemoryRateLimiter
+from url_shortener.core.rate_limit import NoOpRateLimiter, RateLimiter, ValkeyRateLimiter
+from url_shortener.db.postgres import db_manager
+from url_shortener.db.valkey import valkey_manager
+from url_shortener.repositories.analytics_repository import AnalyticsRepository
+from url_shortener.repositories.url_repository import URLRepository
 from url_shortener.services.analytics_service import AnalyticsService
 from url_shortener.services.redirect_service import RedirectService
 from url_shortener.services.url_service import URLService
@@ -16,15 +20,34 @@ from url_shortener.services.url_service import URLService
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     settings = get_settings()
-    url_service = URLService(settings)
-    analytics_service = AnalyticsService()
+
+    db_manager.database_url = settings.get_database_url_async()
+    await db_manager.initialize()
+    await db_manager.create_tables()
+
+    rate_limiter: RateLimiter = NoOpRateLimiter()
+    if settings.valkey_url:
+        valkey_manager.valkey_url = settings.valkey_url
+        await valkey_manager.initialize()
+        rate_limiter = ValkeyRateLimiter(settings, valkey_manager)
+
+    url_repository = URLRepository(db_manager)
+    analytics_repository = AnalyticsRepository(db_manager)
+    url_service = URLService(settings, url_repository)
+    analytics_service = AnalyticsService(analytics_repository)
 
     app.state.settings = settings
     app.state.url_service = url_service
     app.state.analytics_service = analytics_service
     app.state.redirect_service = RedirectService(url_service, analytics_service)
-    app.state.rate_limiter = InMemoryRateLimiter(settings)
-    yield
+    app.state.rate_limiter = rate_limiter
+
+    try:
+        yield
+    finally:
+        if settings.valkey_url:
+            await valkey_manager.close()
+        await db_manager.close()
 
 
 app = FastAPI(title="URL Shortener", version="1.0.0", lifespan=lifespan)
@@ -37,6 +60,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
 
 @app.get("/")
 async def root() -> dict[str, str]:

--- a/url_shortener/models/schemas.py
+++ b/url_shortener/models/schemas.py
@@ -69,6 +69,7 @@ class AnalyticsResponse(BaseModel):
 
 
 class URLRecord(BaseModel):
+    id: int
     short_code: str
     original_url: str
     created_at: datetime

--- a/url_shortener/repositories/__init__.py
+++ b/url_shortener/repositories/__init__.py
@@ -1,0 +1,4 @@
+from url_shortener.repositories.analytics_repository import AnalyticsRepository
+from url_shortener.repositories.url_repository import URLRepository
+
+__all__ = ["AnalyticsRepository", "URLRepository"]

--- a/url_shortener/repositories/analytics_repository.py
+++ b/url_shortener/repositories/analytics_repository.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import delete, select
+
+from url_shortener.db.models import Analytics, URL
+from url_shortener.db.postgres import DatabaseManager
+from url_shortener.models.schemas import ClickEvent
+
+
+class AnalyticsRepository:
+    """Database-backed analytics event storage."""
+
+    def __init__(self, database: DatabaseManager):
+        self.database = database
+
+    async def create_event(
+        self,
+        *,
+        url_id: int,
+        timestamp: datetime,
+        ip_address: str | None,
+        referer: str | None,
+        user_agent: str | None,
+        country: str | None,
+        city: str | None,
+        browser: str | None,
+        os_name: str | None,
+        device_type: str,
+    ) -> ClickEvent:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._create_event_sync(
+                    session,
+                    url_id=url_id,
+                    timestamp=timestamp,
+                    ip_address=ip_address,
+                    referer=referer,
+                    user_agent=user_agent,
+                    country=country,
+                    city=city,
+                    browser=browser,
+                    os_name=os_name,
+                    device_type=device_type,
+                )
+            )
+
+        async with self.database.get_session() as session:
+            event = Analytics(
+                url_id=url_id,
+                timestamp=timestamp,
+                ip_address=ip_address or "unknown",
+                referer=referer,
+                user_agent=user_agent,
+                country=country,
+                city=city,
+                browser=browser,
+                os=os_name,
+                device_type=device_type,
+            )
+            session.add(event)
+            await session.flush()
+            await session.refresh(event)
+            return self._to_click_event(event)
+
+    async def list_events(self, url_id: int) -> list[ClickEvent]:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(lambda session: self._list_events_sync(session, url_id))
+
+        async with self.database.get_session() as session:
+            result = await session.execute(
+                select(Analytics)
+                .where(Analytics.url_id == url_id)
+                .order_by(Analytics.timestamp.desc())
+            )
+            return [self._to_click_event(event) for event in result.scalars().all()]
+
+    async def delete_events_for_short_code(self, short_code: str) -> None:
+        if self.database.is_sqlite:
+            await self.database.run_sync(
+                lambda session: self._delete_events_for_short_code_sync(session, short_code)
+            )
+            return
+
+        async with self.database.get_session() as session:
+            url_id_result = await session.execute(
+                select(URL.id).where(URL.short_code == short_code).limit(1)
+            )
+            url_id = url_id_result.scalar_one_or_none()
+            if url_id is None:
+                return
+            await session.execute(delete(Analytics).where(Analytics.url_id == url_id))
+
+    def _create_event_sync(
+        self,
+        session,
+        *,
+        url_id: int,
+        timestamp: datetime,
+        ip_address: str | None,
+        referer: str | None,
+        user_agent: str | None,
+        country: str | None,
+        city: str | None,
+        browser: str | None,
+        os_name: str | None,
+        device_type: str,
+    ) -> ClickEvent:
+        event = Analytics(
+            url_id=url_id,
+            timestamp=timestamp,
+            ip_address=ip_address or "unknown",
+            referer=referer,
+            user_agent=user_agent,
+            country=country,
+            city=city,
+            browser=browser,
+            os=os_name,
+            device_type=device_type,
+        )
+        session.add(event)
+        session.flush()
+        session.refresh(event)
+        return self._to_click_event(event)
+
+    def _list_events_sync(self, session, url_id: int) -> list[ClickEvent]:
+        result = session.execute(
+            select(Analytics).where(Analytics.url_id == url_id).order_by(Analytics.timestamp.desc())
+        )
+        return [self._to_click_event(event) for event in result.scalars().all()]
+
+    def _delete_events_for_short_code_sync(self, session, short_code: str) -> None:
+        url_id_result = session.execute(select(URL.id).where(URL.short_code == short_code).limit(1))
+        url_id = url_id_result.scalar_one_or_none()
+        if url_id is None:
+            return
+        session.execute(delete(Analytics).where(Analytics.url_id == url_id))
+
+    def _to_click_event(self, event: Analytics) -> ClickEvent:
+        return ClickEvent(
+            timestamp=event.timestamp,
+            ip_address=event.ip_address,
+            referer=event.referer,
+            user_agent=event.user_agent,
+            country=event.country,
+            city=event.city,
+            browser=event.browser,
+            os=event.os,
+            device_type=event.device_type or "desktop",
+        )

--- a/url_shortener/repositories/url_repository.py
+++ b/url_shortener/repositories/url_repository.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from url_shortener.db.models import URL
+from url_shortener.db.postgres import DatabaseManager
+from url_shortener.models.schemas import URLRecord
+
+
+class URLRepository:
+    """Database-backed data access for shortened URLs."""
+
+    def __init__(self, database: DatabaseManager):
+        self.database = database
+
+    async def create_url(
+        self,
+        *,
+        short_code: str,
+        original_url: str,
+        created_at: datetime,
+        expires_at: datetime | None,
+        custom_alias: str | None,
+    ) -> URLRecord:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._create_url_sync(
+                    session,
+                    short_code=short_code,
+                    original_url=original_url,
+                    created_at=created_at,
+                    expires_at=expires_at,
+                    custom_alias=custom_alias,
+                )
+            )
+
+        async with self.database.get_session() as session:
+            url = URL(
+                short_code=short_code,
+                original_url=original_url,
+                created_at=created_at,
+                expires_at=expires_at,
+                custom_alias=custom_alias,
+            )
+            session.add(url)
+            try:
+                await session.flush()
+            except IntegrityError:
+                raise
+            await session.refresh(url)
+            return self._to_record(url)
+
+    async def list_urls(self) -> list[URLRecord]:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(self._list_urls_sync)
+
+        async with self.database.get_session() as session:
+            result = await session.execute(select(URL).order_by(URL.created_at.desc()))
+            return [self._to_record(url) for url in result.scalars().all()]
+
+    async def get_by_short_code(self, short_code: str) -> URLRecord | None:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._get_by_short_code_sync(session, short_code)
+            )
+
+        async with self.database.get_session() as session:
+            result = await session.execute(select(URL).where(URL.short_code == short_code))
+            url = result.scalar_one_or_none()
+            return self._to_record(url) if url else None
+
+    async def short_code_exists(self, short_code: str) -> bool:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._short_code_exists_sync(session, short_code)
+            )
+
+        async with self.database.get_session() as session:
+            result = await session.execute(
+                select(URL.id).where(URL.short_code == short_code).limit(1)
+            )
+            return result.scalar_one_or_none() is not None
+
+    async def set_url_active_state(self, short_code: str, is_active: bool) -> URLRecord | None:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._set_active_state_sync(session, short_code, is_active)
+            )
+
+        async with self.database.get_session() as session:
+            result = await session.execute(select(URL).where(URL.short_code == short_code))
+            url = result.scalar_one_or_none()
+            if url is None:
+                return None
+            url.is_active = is_active
+            await session.flush()
+            await session.refresh(url)
+            return self._to_record(url)
+
+    async def increment_clicks(self, short_code: str) -> URLRecord | None:
+        if self.database.is_sqlite:
+            return await self.database.run_sync(
+                lambda session: self._increment_clicks_sync(session, short_code)
+            )
+
+        async with self.database.get_session() as session:
+            result = await session.execute(select(URL).where(URL.short_code == short_code))
+            url = result.scalar_one_or_none()
+            if url is None:
+                return None
+            url.click_count += 1
+            await session.flush()
+            await session.refresh(url)
+            return self._to_record(url)
+
+    def _create_url_sync(
+        self,
+        session,
+        *,
+        short_code: str,
+        original_url: str,
+        created_at: datetime,
+        expires_at: datetime | None,
+        custom_alias: str | None,
+    ) -> URLRecord:
+        url = URL(
+            short_code=short_code,
+            original_url=original_url,
+            created_at=created_at,
+            expires_at=expires_at,
+            custom_alias=custom_alias,
+        )
+        session.add(url)
+        session.flush()
+        session.refresh(url)
+        return self._to_record(url)
+
+    def _list_urls_sync(self, session) -> list[URLRecord]:
+        result = session.execute(select(URL).order_by(URL.created_at.desc()))
+        return [self._to_record(url) for url in result.scalars().all()]
+
+    def _get_by_short_code_sync(self, session, short_code: str) -> URLRecord | None:
+        result = session.execute(select(URL).where(URL.short_code == short_code))
+        url = result.scalar_one_or_none()
+        return self._to_record(url) if url else None
+
+    def _short_code_exists_sync(self, session, short_code: str) -> bool:
+        result = session.execute(select(URL.id).where(URL.short_code == short_code).limit(1))
+        return result.scalar_one_or_none() is not None
+
+    def _set_active_state_sync(self, session, short_code: str, is_active: bool) -> URLRecord | None:
+        result = session.execute(select(URL).where(URL.short_code == short_code))
+        url = result.scalar_one_or_none()
+        if url is None:
+            return None
+        url.is_active = is_active
+        session.flush()
+        session.refresh(url)
+        return self._to_record(url)
+
+    def _increment_clicks_sync(self, session, short_code: str) -> URLRecord | None:
+        result = session.execute(select(URL).where(URL.short_code == short_code))
+        url = result.scalar_one_or_none()
+        if url is None:
+            return None
+        url.click_count += 1
+        session.flush()
+        session.refresh(url)
+        return self._to_record(url)
+
+    def _to_record(self, url: URL) -> URLRecord:
+        return URLRecord(
+            id=url.id,
+            short_code=url.short_code,
+            original_url=url.original_url,
+            created_at=url.created_at,
+            expires_at=url.expires_at,
+            click_count=url.click_count,
+            is_active=url.is_active,
+            custom_alias=url.custom_alias,
+        )

--- a/url_shortener/services/analytics_service.py
+++ b/url_shortener/services/analytics_service.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Dict, List
 
 from fastapi import Request
 
 from url_shortener.models.schemas import AnalyticsAggregate, ClickEvent, URLRecord
+from url_shortener.repositories.analytics_repository import AnalyticsRepository
 
 
 class AnalyticsService:
     """Collects click metadata for shortened URLs."""
 
-    def __init__(self) -> None:
-        self._events: Dict[str, List[ClickEvent]] = defaultdict(list)
+    def __init__(self, repository: AnalyticsRepository) -> None:
+        self.repository = repository
 
     async def track_click(self, url: URLRecord, request: Request) -> ClickEvent:
         user_agent = request.headers.get("user-agent")
@@ -29,23 +28,24 @@ class AnalyticsService:
         browser = self._detect_browser(user_agent)
         os_name = self._detect_os(user_agent)
 
-        event = ClickEvent(
+        return await self.repository.create_event(
+            url_id=url.id,
             timestamp=datetime.now(timezone.utc),
             ip_address=ip_address,
             referer=referer,
             user_agent=user_agent,
+            country=None,
+            city=None,
             browser=browser,
-            os=os_name,
+            os_name=os_name,
             device_type=device_type,
         )
-        self._events[url.short_code].append(event)
-        return event
 
     async def get_analytics(self, url: URLRecord) -> AnalyticsAggregate:
-        return AnalyticsAggregate(url=url, clicks=list(self._events.get(url.short_code, [])))
+        return AnalyticsAggregate(url=url, clicks=await self.repository.list_events(url.id))
 
     async def delete_analytics(self, short_code: str) -> None:
-        self._events.pop(short_code, None)
+        await self.repository.delete_events_for_short_code(short_code)
 
     def _detect_device(self, user_agent: str | None) -> str:
         agent = (user_agent or "").lower()

--- a/url_shortener/services/url_service.py
+++ b/url_shortener/services/url_service.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
 
 from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
 
 from url_shortener.core.config import Settings
 from url_shortener.models.schemas import URLCreateRequest, URLRecord
+from url_shortener.repositories.url_repository import URLRepository
 from url_shortener.utils.id_generator import get_id_generator
 
 
 class URLService:
-    """Stores and manages shortened URLs in memory."""
+    """Coordinates URL persistence and domain rules."""
 
-    def __init__(self, settings: Settings):
+    def __init__(self, settings: Settings, repository: URLRepository):
         self.settings = settings
-        self._urls: Dict[str, URLRecord] = {}
+        self.repository = repository
         self._generator = get_id_generator()
 
     async def create_short_url(self, payload: URLCreateRequest) -> URLRecord:
         short_code = payload.custom_alias or await self._generate_unique_code()
-        if short_code in self._urls:
+        if await self.repository.short_code_exists(short_code):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Short code already exists",
@@ -30,21 +31,25 @@ class URLService:
         if payload.expires_in_days is not None:
             expires_at = datetime.now(timezone.utc) + timedelta(days=payload.expires_in_days)
 
-        record = URLRecord(
-            short_code=short_code,
-            original_url=str(payload.url),
-            created_at=datetime.now(timezone.utc),
-            expires_at=expires_at,
-            custom_alias=payload.custom_alias,
-        )
-        self._urls[short_code] = record
-        return record
+        try:
+            return await self.repository.create_url(
+                short_code=short_code,
+                original_url=str(payload.url),
+                created_at=datetime.now(timezone.utc),
+                expires_at=expires_at,
+                custom_alias=payload.custom_alias,
+            )
+        except IntegrityError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Short code already exists",
+            ) from exc
 
-    async def list_urls(self) -> List[URLRecord]:
-        return sorted(self._urls.values(), key=lambda item: item.created_at, reverse=True)
+    async def list_urls(self) -> list[URLRecord]:
+        return await self.repository.list_urls()
 
-    async def get_url(self, short_code: str) -> Optional[URLRecord]:
-        return self._urls.get(short_code)
+    async def get_url(self, short_code: str) -> URLRecord | None:
+        return await self.repository.get_by_short_code(short_code)
 
     async def require_active_url(self, short_code: str) -> URLRecord:
         record = await self.get_url(short_code)
@@ -53,7 +58,7 @@ class URLService:
         if not record.is_active:
             raise HTTPException(status_code=status.HTTP_410_GONE, detail="Short URL is inactive")
         if record.expires_at and record.expires_at <= datetime.now(timezone.utc):
-            record.is_active = False
+            await self.repository.set_url_active_state(short_code, False)
             raise HTTPException(status_code=status.HTTP_410_GONE, detail="Short URL has expired")
         return record
 
@@ -61,16 +66,18 @@ class URLService:
         record = await self.get_url(short_code)
         if record is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Short URL not found")
-        record.is_active = False
+        await self.repository.set_url_active_state(short_code, False)
 
     async def increment_clicks(self, short_code: str) -> URLRecord:
-        record = await self.require_active_url(short_code)
-        record.click_count += 1
+        await self.require_active_url(short_code)
+        record = await self.repository.increment_clicks(short_code)
+        if record is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Short URL not found")
         return record
 
     async def _generate_unique_code(self) -> str:
         async def exists(candidate: str) -> bool:
-            return candidate in self._urls
+            return await self.repository.short_code_exists(candidate)
 
         candidate = await self._generator.generate_collision_free(
             exists,


### PR DESCRIPTION
### Motivation
- Replace ephemeral in-memory storage with persistent repositories so the app can run across processes and persist URL and analytics data in a real database.
- Move business logic out of service-local collections and into repository/data-access layers to separate concerns and enable SQL-backed operations.
- Use Valkey-backed shared rate limiting when configured and provide a no-op fallback for local/test runs.
- Ensure the application initializes DB/cache resources at FastAPI lifespan so routes receive fully wired services.

### Description
- Added `url_shortener/repositories/URLRepository` and `AnalyticsRepository` to persist URL and analytics records via `url_shortener/db/postgres.py` and `url_shortener/db/models.py` instead of in-memory structures.
- Refactored `URLService` and `AnalyticsService` to delegate create/list/read/delete/increment and click tracking to the new repositories and to use `URLRecord.id` for analytics linkage.
- Reworked `url_shortener/db/postgres.py` to support both async DB engines and a synchronous sqlite path for tests by exposing `run_sync` and `is_sqlite` helpers and updated lifespan startup to initialize/create tables.
- Updated `url_shortener/main.py` lifespan to initialize `db_manager` and (optionally) `valkey_manager`, create repositories and services, inject them into `app.state`, and tear down resources on shutdown; replaced the old in-memory limiter with a `ValkeyRateLimiter` (when `valkey_url` is set) and a `NoOpRateLimiter` fallback.
- Added repository package exports and adjusted API/route type hints and dependency wiring to use the new `RateLimiter` protocol and repository-backed services.
- Added a test helper in `tests/conftest.py` to use an isolated sqlite file for tests and appended `aiosqlite` to `requirements.txt` to document local async sqlite usage.

### Testing
- Ran `python -m compileall url_shortener tests` to validate imports and byte-compile modules, which succeeded.
- Ran `pytest -q` which completed successfully with `4 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1923386548320b7079b825a024ffa)