### PR TITLE
Integrate frontend with FastAPI backend, add AI stubs and CORS improvements

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ function App() {
           <Routes location={location}>
             <Route path="/" element={<Home />} />
             <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/analytics/:id" element={<Analytics />} />
+            <Route path="/analytics/:shortCode" element={<Analytics />} />
             <Route path="/login" element={<Login />} />
             <Route path="/home" element={<Navigate to="/" replace />} />
             <Route path="*" element={<NotFound />} />

--- a/frontend/src/components/CreateUrlModal.jsx
+++ b/frontend/src/components/CreateUrlModal.jsx
@@ -9,13 +9,21 @@ export default function CreateUrlModal({ open, onClose, onCreate }) {
   const [alias, setAlias] = useState('')
   const [result, setResult] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   async function submit(e) {
     e.preventDefault()
     setLoading(true)
-    const created = await onCreate({ url, customAlias: alias || undefined })
-    setResult(created)
-    setLoading(false)
+    setError('')
+    try {
+      const created = await onCreate({ url, customAlias: alias || undefined })
+      setResult(created)
+    } catch (err) {
+      setError(err.message)
+      setResult(null)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -33,6 +41,8 @@ export default function CreateUrlModal({ open, onClose, onCreate }) {
               <input className="input-dark" value={alias} onChange={(e) => setAlias(e.target.value)} placeholder="Alias (optional)" />
               <GradientButton type="submit" disabled={loading}>{loading ? 'Generating...' : 'Generate URL'}</GradientButton>
             </form>
+
+            {error && <p className="mt-3 text-sm text-brand-error">{error}</p>}
 
             {result?.shortUrl && (
               <div className="mt-4 rounded-xl border border-brand-success/30 bg-brand-success/10 p-3 text-sm">

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from 'react-router-dom'
 const items = [
   { to: '/dashboard', icon: Home, label: 'Overview' },
   { to: '/dashboard', icon: Link2, label: 'Links' },
-  { to: '/analytics/demo-1', icon: BarChart3, label: 'Analytics' }
+  { to: '/dashboard', icon: BarChart3, label: 'Analytics' }
 ]
 
 export default function Sidebar({ mobileOpen, onClose }) {

--- a/frontend/src/components/UrlForm.jsx
+++ b/frontend/src/components/UrlForm.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import GradientButton from './GradientButton'
 import CopyButton from './CopyButton'
+import { api } from '../services/api'
 
-export default function UrlForm({ onSubmit, loading, result }) {
+export default function UrlForm({ onSubmit, loading, result, error }) {
   const [url, setUrl] = useState('')
   const [customAlias, setCustomAlias] = useState('')
+  const [aiMessage, setAiMessage] = useState('')
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -12,36 +14,52 @@ export default function UrlForm({ onSubmit, loading, result }) {
     await onSubmit({ url: url.trim(), customAlias: customAlias.trim() || undefined })
   }
 
+  async function handleAutoAlias() {
+    setAiMessage('')
+    try {
+      const generated = await api.generateSmartAlias(url.trim())
+      setCustomAlias(generated.alias || '')
+    } catch (err) {
+      setAiMessage(err.message)
+    }
+  }
+
   return (
     <div>
       <form className="grid gap-3" onSubmit={handleSubmit}>
-        <input 
-          value={url} 
-          onChange={(e) => setUrl(e.target.value)} 
-          className="input-dark" 
-          placeholder="Enter your long URL here" 
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="input-dark"
+          placeholder="Enter your long URL here"
           autoFocus
         />
-        <input 
-          value={customAlias} 
-          onChange={(e) => setCustomAlias(e.target.value)} 
-          className="input-dark" 
-          placeholder="Optional: Custom alias" 
-        />
+        <div className="flex gap-2">
+          <input
+            value={customAlias}
+            onChange={(e) => setCustomAlias(e.target.value)}
+            className="input-dark"
+            placeholder="Optional: Custom alias"
+          />
+          <button type="button" onClick={handleAutoAlias} className="btn-secondary px-4">Auto</button>
+        </div>
         <GradientButton type="submit" disabled={loading} className="px-8 py-3.5 text-base">
           {loading ? 'Creating…' : 'Create Short Link'}
         </GradientButton>
       </form>
+
+      {error && <p className="mt-3 text-sm text-brand-error">{error}</p>}
+      {aiMessage && <p className="mt-3 text-sm text-brand-warning">{aiMessage}</p>}
 
       {result?.shortUrl && (
         <div className="mt-6 rounded-xl border border-brand-success/40 bg-gradient-to-br from-brand-success/15 to-brand-success/10 p-4">
           <p className="text-xs font-semibold uppercase tracking-widest text-brand-success">Success</p>
           <p className="text-sm text-brand-muted mt-1">Your short link is ready to share</p>
           <div className="mt-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-            <a 
-              href={result.shortUrl} 
-              target="_blank" 
-              rel="noreferrer" 
+            <a
+              href={result.shortUrl}
+              target="_blank"
+              rel="noreferrer"
               className="font-mono text-base text-brand-text bg-white/5 rounded-lg px-4 py-2.5 border border-white/10 hover:bg-white/10 transition flex-1"
             >
               {result.shortUrl}

--- a/frontend/src/components/UrlTable.jsx
+++ b/frontend/src/components/UrlTable.jsx
@@ -21,7 +21,7 @@ export default function UrlTable({ items, onDelete }) {
           </thead>
           <tbody>
             {items.map((item) => (
-              <tr key={item.id || item.shortId} className="border-b border-white/5">
+              <tr key={item.shortCode || item.shortId} className="border-b border-white/5">
                 <td className="px-4 py-3 font-mono text-xs sm:text-sm">{item.shortUrl}</td>
                 <td className="px-4 py-3 text-brand-muted">{truncateUrl(item.url, 56)}</td>
                 <td className="px-4 py-3">{item.clicks}</td>
@@ -34,8 +34,8 @@ export default function UrlTable({ items, onDelete }) {
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
                     <CopyButton value={item.shortUrl} compact />
-                    <Link to={`/analytics/${item.shortId}`} className="btn-secondary p-2"><BarChart3 size={14} /></Link>
-                    <button onClick={() => onDelete(item.shortId)} className="btn-secondary p-2 text-brand-error"><Trash2 size={14} /></button>
+                    <Link to={`/analytics/${item.shortCode || item.shortId}`} className="btn-secondary p-2"><BarChart3 size={14} /></Link>
+                    <button onClick={() => onDelete(item.shortCode || item.shortId)} className="btn-secondary p-2 text-brand-error"><Trash2 size={14} /></button>
                   </div>
                 </td>
               </tr>

--- a/frontend/src/hooks/useUrls.js
+++ b/frontend/src/hooks/useUrls.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { deleteUrl, getUrls, shortenUrl } from '../services/api'
+import { api } from '../services/api'
 
 export default function useUrls() {
   const [urls, setUrls] = useState([])
@@ -7,20 +7,23 @@ export default function useUrls() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    const data = await getUrls()
-    setUrls(data)
-    setLoading(false)
+    try {
+      const data = await api.getUrls()
+      setUrls(data)
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
   const create = useCallback(async (payload) => {
-    const created = await shortenUrl(payload)
+    const created = await api.shorten(payload.url, payload.customAlias)
     setUrls((prev) => [created, ...prev])
     return created
   }, [])
 
-  const remove = useCallback(async (id) => {
-    await deleteUrl(id)
-    setUrls((prev) => prev.filter((item) => item.shortId !== id))
+  const remove = useCallback(async (shortCode) => {
+    await api.deleteUrl(shortCode)
+    setUrls((prev) => prev.filter((item) => item.shortCode !== shortCode))
   }, [])
 
   useEffect(() => {
@@ -34,7 +37,7 @@ export default function useUrls() {
       total: urls.length,
       totalClicks,
       active,
-      top: urls.slice().sort((a, b) => b.clicks - a.clicks)[0]?.shortId || '—'
+      top: urls.slice().sort((a, b) => b.clicks - a.clicks)[0]?.shortCode || '—'
     }
   }, [urls])
 

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -5,16 +5,32 @@ import CopyButton from '../components/CopyButton'
 import LoadingSpinner from '../components/LoadingSpinner'
 import StatsCard from '../components/StatsCard'
 import TopUrlsChart from '../components/TopUrlsChart'
-import { getAnalytics } from '../services/api'
-import formatDate from '../utils/formatDate'
+import { api } from '../services/api'
 
 export default function Analytics() {
-  const { id } = useParams()
+  const { shortCode } = useParams()
   const [data, setData] = useState(null)
+  const [error, setError] = useState('')
+  const [insight, setInsight] = useState('')
 
   useEffect(() => {
-    getAnalytics(id).then(setData)
-  }, [id])
+    setError('')
+    setData(null)
+    api.getAnalytics(shortCode).then(setData).catch((err) => setError(err.message))
+  }, [shortCode])
+
+  async function runDiagnostic() {
+    setInsight('')
+    try {
+      await api.getAiInsight(data)
+    } catch (err) {
+      setInsight(err.message)
+    }
+  }
+
+  if (error) {
+    return <div className="mx-auto max-w-7xl px-4 py-8 text-brand-error">{error}</div>
+  }
 
   if (!data) {
     return <div className="mx-auto max-w-7xl px-4 py-8"><LoadingSpinner label="Loading analytics" /></div>
@@ -27,11 +43,11 @@ export default function Analytics() {
         <h1 className="mt-2 text-xl font-semibold">{data.shortUrl}</h1>
         <p className="mt-1 text-sm text-brand-muted">{data.originalUrl}</p>
         <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-brand-slate">
-          <span>Created {formatDate(data.createdAt)}</span>
-          <span>•</span>
           <span>{data.totalClicks} total clicks</span>
           <CopyButton value={data.shortUrl} compact />
+          <button onClick={runDiagnostic} className="btn-secondary px-3 py-1">Run Diagnostic</button>
         </div>
+        {insight && <p className="mt-2 text-sm text-brand-warning">{insight}</p>}
       </header>
 
       <section className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -46,12 +62,34 @@ export default function Analytics() {
         <div className="xl:col-span-2"><TopUrlsChart data={data.topUrls} /></div>
       </section>
 
+      <section className="mt-5 grid gap-5 xl:grid-cols-2">
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-brand-muted">Browser breakdown</h3>
+          <TopUrlsChart data={data.browsers} />
+        </div>
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-brand-muted">Device breakdown</h3>
+          <TopUrlsChart data={data.devices} />
+        </div>
+      </section>
+
       <section className="glass-card mt-5 p-5">
-        <h3 className="text-sm font-medium text-brand-muted">Analytics summary</h3>
-        <p className="mt-2 text-sm leading-7 text-brand-muted">
-          This link shows steady growth with a strong recent click trend. Performance spikes indicate campaign bursts,
-          while average daily engagement remains healthy for ongoing distribution.
-        </p>
+        <h3 className="text-sm font-medium text-brand-muted">Recent click events</h3>
+        {data.recentClicks.length === 0 ? (
+          <p className="mt-2 text-sm text-brand-muted">No click events recorded yet.</p>
+        ) : (
+          <div className="mt-3 space-y-2 text-sm">
+            {data.recentClicks.slice(0, 5).map((click) => (
+              <div key={`${click.timestamp}-${click.ip_address || 'na'}`} className="rounded-lg bg-white/5 px-3 py-2">
+                <span>{new Date(click.timestamp).toLocaleString()}</span>
+                <span className="mx-2">•</span>
+                <span>{click.referer || 'direct'}</span>
+                <span className="mx-2">•</span>
+                <span>{click.browser || 'unknown'} / {click.device_type || 'unknown'}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   )

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,19 +2,26 @@ import { BarChart3, ShieldCheck, Zap, Sparkles, TrendingUp, Lock } from 'lucide-
 import { useState } from 'react'
 import FeatureCard from '../components/FeatureCard'
 import HeroSection from '../components/HeroSection'
-import StatsCard from '../components/StatsCard'
 import UrlForm from '../components/UrlForm'
-import { shortenUrl } from '../services/api'
+import { api } from '../services/api'
 
 export default function Home() {
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState(null)
+  const [error, setError] = useState('')
 
   async function handleShorten(payload) {
     setLoading(true)
-    const created = await shortenUrl(payload)
-    setResult(created)
-    setLoading(false)
+    setError('')
+    try {
+      const created = await api.shorten(payload.url, payload.customAlias)
+      setResult(created)
+    } catch (err) {
+      setResult(null)
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -28,7 +35,7 @@ export default function Home() {
           </div>
           <h2 className="text-3xl font-bold text-brand-text">Create Your First Link</h2>
           <p className="mt-3 text-brand-muted">Enter a URL and get a shareable link instantly. No signup required.</p>
-          <UrlForm onSubmit={handleShorten} loading={loading} result={result} />
+          <UrlForm onSubmit={handleShorten} loading={loading} result={result} error={error} />
         </div>
       </section>
 
@@ -40,34 +47,34 @@ export default function Home() {
         </div>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <FeatureCard 
-            icon={Zap} 
-            title="Lightning Fast" 
+          <FeatureCard
+            icon={Zap}
+            title="Lightning Fast"
             description="Redirect in milliseconds with our globally distributed edge network. Optimized for speed."
           />
-          <FeatureCard 
-            icon={BarChart3} 
-            title="Real-time Analytics" 
+          <FeatureCard
+            icon={BarChart3}
+            title="Real-time Analytics"
             description="Track clicks, geographic distribution, and trends with rich dashboards and insights."
           />
-          <FeatureCard 
-            icon={ShieldCheck} 
-            title="Enterprise Security" 
+          <FeatureCard
+            icon={ShieldCheck}
+            title="Enterprise Security"
             description="Built-in security with HTTPS, rate limiting, and audit logs for compliance."
           />
-          <FeatureCard 
-            icon={Sparkles} 
-            title="Easy Integration" 
+          <FeatureCard
+            icon={Sparkles}
+            title="Easy Integration"
             description="REST API for seamless integration into your applications and workflows."
           />
-          <FeatureCard 
-            icon={TrendingUp} 
-            title="Campaign Tracking" 
+          <FeatureCard
+            icon={TrendingUp}
+            title="Campaign Tracking"
             description="Tag links and monitor performance across different campaigns and channels."
           />
-          <FeatureCard 
-            icon={Lock} 
-            title="Private & Reliable" 
+          <FeatureCard
+            icon={Lock}
+            title="Private & Reliable"
             description="Your data stays secure. Self-hosted or cloud options for complete control."
           />
         </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,82 +1,144 @@
-import axios from 'axios'
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '')
 
-const baseURL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '')
+async function parseResponse(response) {
+  if (response.status === 204) {
+    return null
+  }
 
-const client = axios.create({
-  baseURL: baseURL ? `${baseURL}/api/v1` : '/api/v1',
-  timeout: 7000
-})
-
-const mockUrls = [
-  { shortId: 'demo-1', shortUrl: 'https://sho.rt/demo-1', url: 'https://vercel.com/blog/scaling-platforms', clicks: 1382, createdAt: '2026-03-20T08:30:00.000Z', status: 'active' },
-  { shortId: 'api-x7', shortUrl: 'https://sho.rt/api-x7', url: 'https://docs.github.com/en/rest', clicks: 792, createdAt: '2026-03-27T14:10:00.000Z', status: 'active' },
-  { shortId: 'infra99', shortUrl: 'https://sho.rt/infra99', url: 'https://kubernetes.io/docs/concepts/overview/', clicks: 344, createdAt: '2026-02-15T09:45:00.000Z', status: 'paused' }
-]
-
-const mockTrend = [
-  { date: 'Mar 30', clicks: 52 },
-  { date: 'Mar 31', clicks: 68 },
-  { date: 'Apr 01', clicks: 74 },
-  { date: 'Apr 02', clicks: 87 },
-  { date: 'Apr 03', clicks: 102 },
-  { date: 'Apr 04', clicks: 94 },
-  { date: 'Apr 05', clicks: 119 }
-]
-
-export async function shortenUrl(data) {
-  try {
-    const response = await client.post('/shorten', data)
-    return response.data
-  } catch {
-    const alias = data.customAlias || Math.random().toString(36).slice(2, 8)
-    return {
-      shortId: alias,
-      shortUrl: `https://sho.rt/${alias}`,
-      url: data.url,
-      clicks: 0,
-      createdAt: new Date().toISOString(),
-      status: 'active'
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) {
+    const text = await response.text()
+    if (!response.ok) {
+      throw new Error(text || `Request failed with status ${response.status}`)
     }
+    return text
+  }
+
+  try {
+    return await response.json()
+  } catch {
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`)
+    }
+    return null
   }
 }
 
-export async function getUrls() {
+async function request(path, options = {}) {
+  let response
   try {
-    const response = await client.get('/urls')
-    return response.data
+    response = await fetch(`${API_BASE_URL}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {})
+      },
+      ...options
+    })
   } catch {
-    return mockUrls
+    throw new Error('Unable to reach backend server')
+  }
+
+  const payload = await parseResponse(response)
+  if (!response.ok) {
+    const detail = payload && typeof payload === 'object' && 'detail' in payload ? payload.detail : null
+    throw new Error(detail || `Request failed with status ${response.status}`)
+  }
+
+  return payload
+}
+
+function mapUrl(item) {
+  return {
+    shortCode: item.short_code,
+    shortId: item.short_code,
+    shortUrl: item.short_url,
+    url: item.original_url,
+    originalUrl: item.original_url,
+    createdAt: item.created_at,
+    clicks: item.click_count ?? 0,
+    status: item.is_active === false ? 'inactive' : 'active'
   }
 }
 
-export async function getAnalytics(id) {
-  try {
-    const response = await client.get(`/analytics/${id}`)
-    return response.data
-  } catch {
-    const link = mockUrls.find((item) => item.shortId === id) || mockUrls[0]
-    const total = mockTrend.reduce((acc, point) => acc + point.clicks, 0)
+function toDateLabel(date) {
+  return date.toLocaleDateString('en-US', { month: 'short', day: '2-digit' })
+}
+
+function buildTrend(recentClicks = []) {
+  const today = new Date()
+  const days = []
+  for (let i = 6; i >= 0; i -= 1) {
+    const date = new Date(today)
+    date.setUTCDate(today.getUTCDate() - i)
+    days.push(date)
+  }
+
+  const counts = new Map(days.map((day) => [toDateLabel(day), 0]))
+  recentClicks.forEach((click) => {
+    const date = new Date(click.timestamp)
+    const key = toDateLabel(date)
+    if (counts.has(key)) {
+      counts.set(key, counts.get(key) + 1)
+    }
+  })
+
+  return Array.from(counts.entries()).map(([date, clicks]) => ({ date, clicks }))
+}
+
+function toChartList(breakdown = {}) {
+  return Object.entries(breakdown).map(([shortId, clicks]) => ({ shortId, clicks }))
+}
+
+export const api = {
+  async shorten(url, alias) {
+    const payload = await request('/api/v1/shorten', {
+      method: 'POST',
+      body: JSON.stringify({
+        url,
+        custom_alias: alias || null
+      })
+    })
+
+    return mapUrl(payload)
+  },
+
+  async getUrls() {
+    const payload = await request('/api/v1/shorten')
+    return Array.isArray(payload) ? payload.map(mapUrl) : []
+  },
+
+  async deleteUrl(shortCode) {
+    await request(`/api/v1/shorten/${shortCode}`, { method: 'DELETE' })
+    return { success: true }
+  },
+
+  async getAnalytics(shortCode) {
+    const payload = await request(`/api/v1/analytics/${shortCode}`)
+    const trend = buildTrend(payload.recent_clicks)
+    const totalTrendClicks = trend.reduce((sum, point) => sum + point.clicks, 0)
+    const peakDay = trend.reduce((max, point) => (point.clicks > max.clicks ? point : max), trend[0] || { date: '—', clicks: 0 })
 
     return {
-      shortId: link.shortId,
-      shortUrl: link.shortUrl,
-      originalUrl: link.url,
-      createdAt: link.createdAt,
-      totalClicks: total,
-      last7Days: mockTrend.reduce((acc, point) => acc + point.clicks, 0),
-      peakDay: mockTrend.reduce((max, point) => (point.clicks > max.clicks ? point : max), mockTrend[0]),
-      avgDaily: Math.round(total / mockTrend.length),
-      trend: mockTrend,
-      topUrls: mockUrls.map((item) => ({ shortId: item.shortId, clicks: item.clicks }))
+      shortCode: payload.short_code,
+      shortUrl: payload.short_url,
+      originalUrl: payload.original_url,
+      totalClicks: payload.total_clicks ?? 0,
+      last7Days: totalTrendClicks,
+      peakDay,
+      avgDaily: trend.length ? Math.round(totalTrendClicks / trend.length) : 0,
+      trend,
+      topUrls: toChartList(payload.top_referrers),
+      browsers: toChartList(payload.browser_breakdown),
+      devices: toChartList(payload.device_breakdown),
+      recentClicks: payload.recent_clicks || []
     }
-  }
-}
+  },
 
-export async function deleteUrl(id) {
-  try {
-    await client.delete(`/urls/${id}`)
-    return { success: true }
-  } catch {
-    return { success: true }
+  async generateSmartAlias() {
+    throw new Error('AI backend route not implemented yet')
+  },
+
+  async getAiInsight() {
+    throw new Error('AI backend route not implemented yet')
   }
 }

--- a/url_shortener/api/ai.py
+++ b/url_shortener/api/ai.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+
+
+class AliasRequest(BaseModel):
+    url: str
+
+
+class InsightRequest(BaseModel):
+    data: dict
+
+
+@router.post("/alias")
+async def ai_alias(_: AliasRequest):
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="AI route not implemented yet",
+    )
+
+
+@router.post("/insight")
+async def ai_insight(_: InsightRequest):
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="AI route not implemented yet",
+    )

--- a/url_shortener/core/config.py
+++ b/url_shortener/core/config.py
@@ -1,8 +1,7 @@
 from functools import lru_cache
 from pathlib import Path
-from typing import List
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -21,10 +20,6 @@ class Settings(BaseSettings):
     debug: bool = False
     api_v1_prefix: str = "/api/v1"
     base_domain: str = "http://localhost:8000"
-    database_url: str = (
-        "postgresql+asyncpg://postgres:postgres@localhost:5432/url_shortener"
-    )
-    valkey_url: str = "redis://localhost:6379/0"
     short_code_length: int = 6
     max_short_code_length: int = 10
     default_url_ttl_days: int = 365
@@ -35,9 +30,23 @@ class Settings(BaseSettings):
         default_factory=lambda: f"sqlite+aiosqlite:///{Path.cwd() / 'url_shortener.db'}"
     )
     valkey_url: str | None = None
-    allowed_origins: List[str] = Field(
-        default_factory=lambda: ["http://localhost:3000", "http://localhost:8080"]
+    allowed_origins: list[str] = Field(
+        default_factory=lambda: [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://localhost:8080",
+        ]
     )
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def parse_allowed_origins(cls, value):
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                return value
+            return [origin.strip() for origin in stripped.split(",") if origin.strip()]
+        return value
 
     def normalized_base_domain(self) -> str:
         return self.base_domain.rstrip("/")

--- a/url_shortener/main.py
+++ b/url_shortener/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from url_shortener.api.ai import router as ai_router
 from url_shortener.api.analytics import router as analytics_router
 from url_shortener.api.redirect import router as redirect_router
 from url_shortener.api.shorten import router as shorten_router
@@ -77,4 +78,5 @@ async def healthcheck() -> dict[str, str]:
 
 app.include_router(shorten_router, prefix=settings.api_v1_prefix)
 app.include_router(analytics_router, prefix=settings.api_v1_prefix)
+app.include_router(ai_router, prefix=settings.api_v1_prefix)
 app.include_router(redirect_router)


### PR DESCRIPTION
### Motivation
- Replace frontend mock/fake data with real backend integration so create/list/delete/analytics use the actual FastAPI routes. 
- Make frontend API base configurable via environment (`VITE_API_BASE_URL`) for local and deployed setups. 
- Ensure AI buttons surface real backend state (graceful not-implemented behavior) rather than producing fake data. 
- Improve CORS/allowed origins handling so the backend accepts common local frontend hosts. 

### Description
- Replaced the mocked frontend service with a real client exported as `api` in `frontend/src/services/api.js` that calls the existing backend endpoints (`POST /api/v1/shorten`, `GET /api/v1/shorten`, `DELETE /api/v1/shorten/{short_code}`, `GET /api/v1/analytics/{short_code}`) and maps backend response shapes to the UI model. 
- Hooked UI flows to the real API by updating `frontend/src/hooks/useUrls.js`, `frontend/src/pages/Home.jsx`, `frontend/src/pages/Analytics.jsx`, `frontend/src/components/UrlForm.jsx`, `frontend/src/components/CreateUrlModal.jsx`, `frontend/src/components/UrlTable.jsx`, `frontend/src/components/Sidebar.jsx`, and `frontend/src/App.jsx` so create/list/delete/analytics navigate and render using backend `short_code` identifiers. 
- Added environment example file `frontend/.env.example` with `VITE_API_BASE_URL=http://localhost:8000` so Vite can pick up the backend base URL in dev and production. 
- Wired AI UI actions to backend-ready methods by adding `api.generateSmartAlias()` and `api.getAiInsight()` that throw a clear "AI backend route not implemented yet" error; added backend placeholder routes `POST /api/v1/ai/alias` and `POST /api/v1/ai/insight` in `url_shortener/api/ai.py` which return HTTP 501 JSON responses, and included the AI router in `url_shortener/main.py`. 
- Improved backend config parsing and CORS defaults in `url_shortener/core/config.py` by adding `http://localhost:5173` and a `field_validator` to allow comma-separated `ALLOWED_ORIGINS`, and kept CORS middleware driven by `settings.allowed_origins`. 

### Testing
- Ran backend test suite with `pytest -q`, which passed: `4 passed`.
- Attempted frontend production build with `npm run build`, which failed due to a pre-existing Tailwind/CSS class issue (`to-white/2` in `frontend/src/index.css`) unrelated to the API integration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49154135883209a4f88dc697f812c)